### PR TITLE
added ros_time_offset parameter

### DIFF
--- a/cfg/Camera1394.cfg
+++ b/cfg/Camera1394.cfg
@@ -101,6 +101,9 @@ gen.add("reset_on_open", bool_t, SensorLevels.RECONFIGURE_CLOSE,
 gen.add("use_ros_time", bool_t, SensorLevels.RECONFIGURE_CLOSE,
         "Timestamp Image and CameraInfo using ros::Time::now()", False)
 
+gen.add("ros_time_offset", double_t, SensorLevels.RECONFIGURE_CLOSE,
+        "Offset to add to ros::Time::now()", 0.0, -5.0, 1.0)
+
 # Format7-specific parameters
 gen.add("binning_x", int_t, SensorLevels.RECONFIGURE_CLOSE,
         "Number of pixels combined for Format7 horizontal binning, use device hints if zero.",

--- a/src/nodes/dev_camera1394.cpp
+++ b/src/nodes/dev_camera1394.cpp
@@ -344,6 +344,7 @@ int Camera1394::open(camera1394::Camera1394Config &newconfig)
   findBayerPattern(newconfig.bayer_pattern.c_str());
 
   use_ros_time_ = newconfig.use_ros_time;
+  ros_time_offset_ = newconfig.ros_time_offset;
 
   //////////////////////////////////////////////////////////////
   // start the device streaming data
@@ -463,7 +464,7 @@ void Camera1394::readData(sensor_msgs::Image& image)
   uint8_t* capture_buffer;
 
   if (use_ros_time_)
-    image.header.stamp = ros::Time::now();
+    image.header.stamp = ros::Time::now() + ros::Duration(ros_time_offset_);
   else
     image.header.stamp = ros::Time((double) frame->timestamp / 1000000.0);
 

--- a/src/nodes/dev_camera1394.h
+++ b/src/nodes/dev_camera1394.h
@@ -119,6 +119,7 @@ namespace camera1394
     bool DoBayerConversion_;
     Format7 format7_;
     bool use_ros_time_;
+    float ros_time_offset_;
 
     void SafeCleanup();
     void findBayerPattern(const char*);


### PR DESCRIPTION
This is a common parameter for sensor nodes and needed to synchronize the timestamps of multiple sensors.
