### PR TITLE
Return corrected parameter values to dynamic_reconfigure (fix #14)

### DIFF
--- a/src/nodes/trigger.cpp
+++ b/src/nodes/trigger.cpp
@@ -427,6 +427,9 @@ bool Trigger::reconfigure(Config *newconfig)
     is_ok = false;
   }
 
+  // if external trigger is OFF then ignore rest of parameters
+  if (DC1394_OFF == on_off) return is_ok;
+
   on_off = (dc1394switch_t) newconfig->software_trigger;
   if (!Trigger::setSoftwareTriggerPowerState(camera_, on_off))
   {


### PR DESCRIPTION
As discussed from [here](https://github.com/ros-drivers/camera1394/issues/14#issuecomment-22672029) there are two ways to update invalid value. First is to use previous values stored in `Features::oldconfig_` and second is to query current value from libdc1394.

This changeset follows the second approach. The main concern for such a way is that in certain situations querying a parameter may also fail. However it seems to be logical for libdc1394 to fail only if the whole feature is not available. So I suspect that call to `Features::hasTrigger()` is a sufficient check.

@jack-oquin Unfortunately external clock is broken on my test system now, so I cannot verify the changes. Also I do not have any IEEE-1394 camera without trigger support. Do you have an opportunity to check it with your devices?
