### PR TITLE
add configurable output rate, different from camera poll rate

### DIFF
--- a/src/nodes/dev_camera1394.h
+++ b/src/nodes/dev_camera1394.h
@@ -76,6 +76,7 @@ namespace camera1394
     int open(camera1394::Camera1394Config &newconfig);
     int close();
     bool readData (sensor_msgs::Image &image);
+    bool pollNoRead();
 
     /** check whether CameraInfo matches current video mode
      *

--- a/src/nodes/driver1394.h
+++ b/src/nodes/driver1394.h
@@ -99,6 +99,8 @@ private:
   std::string camera_name_;             // camera name
   ros::Rate cycle_;                     // polling rate when closed
   uint32_t retries_;                    // count of openCamera() retries
+  float output_rate_hz_;				// output (published) image rate in Hz (0 to disable)
+  ros::Time last_camera_poll_;			// timestamp of last time camera was polled
 
   /** libdc1394 camera device interface */
   boost::shared_ptr<camera1394::Camera1394> dev_;


### PR DESCRIPTION
Added `output_rate_hz` parameter to control the output rate (ie. images processed and published) vs the camera poll rate (`frame_rate`). On most cameras the poll rate indirectly controls device properties such as exposure and affects the imagery. This change allows users to downsample the publication rate without affecting the quality of the imagery. 

`output_rate_hz=0` disables the feature