### PR TITLE
Reconnect to device if max number of consecutive read errors is reached

### DIFF
--- a/cfg/Camera1394.cfg
+++ b/cfg/Camera1394.cfg
@@ -89,6 +89,9 @@ gen.add("frame_id", str_t, SensorLevels.RECONFIGURE_CLOSE,
 gen.add("frame_rate", double_t, SensorLevels.RECONFIGURE_CLOSE,
         "Camera speed (frames per second).", 15.0, 1.875, 240.0)
 
+gen.add("max_consecutive_errors", int_t, SensorLevels.RECONFIGURE_CLOSE,
+        "Max number of consecutive read errors before attempting reconnection (0 to disable).", 0, 0, 1000 )
+
 gen.add("iso_speed", int_t, SensorLevels.RECONFIGURE_CLOSE,
         "Total IEEE 1394 bus bandwidth (Megabits/second).", 400, 100, 3200)
 

--- a/src/nodes/driver1394.cpp
+++ b/src/nodes/driver1394.cpp
@@ -176,7 +176,7 @@ namespace camera1394_driver
     topic_diagnostics_min_freq_ = newconfig.frame_rate - delta;
     topic_diagnostics_max_freq_ = newconfig.frame_rate + delta;
 
-	consecutive_read_errors_ = 0;
+    consecutive_read_errors_ = 0;
     return success;
   }
 
@@ -207,12 +207,12 @@ namespace camera1394_driver
             if (read(image))
               {
                 publish(image);
-                consecutive_read_errors_=0;
+                consecutive_read_errors_ = 0;
               }
             else if ( ++consecutive_read_errors_ > config_.max_consecutive_errors && config_.max_consecutive_errors > 0 )
             {
-            	ROS_WARN("reached %lu consecutive read errrors, disconnecting", consecutive_read_errors_ );
-            	closeCamera();
+              ROS_WARN("reached %lu consecutive read errrors, disconnecting", consecutive_read_errors_ );
+              closeCamera();
             }
           }
       } // release mutex lock

--- a/src/nodes/driver1394.h
+++ b/src/nodes/driver1394.h
@@ -99,7 +99,7 @@ private:
   std::string camera_name_;             // camera name
   ros::Rate cycle_;                     // polling rate when closed
   uint32_t retries_;                    // count of openCamera() retries
-  uint32_t consecutive_read_errors_;	// number of consecutive read errors
+  uint32_t consecutive_read_errors_;   // number of consecutive read errors
   
   /** libdc1394 camera device interface */
   boost::shared_ptr<camera1394::Camera1394> dev_;

--- a/src/nodes/driver1394.h
+++ b/src/nodes/driver1394.h
@@ -99,7 +99,8 @@ private:
   std::string camera_name_;             // camera name
   ros::Rate cycle_;                     // polling rate when closed
   uint32_t retries_;                    // count of openCamera() retries
-
+  uint32_t consecutive_read_errors_;	// number of consecutive read errors
+  
   /** libdc1394 camera device interface */
   boost::shared_ptr<camera1394::Camera1394> dev_;
 


### PR DESCRIPTION
In my tests using PointGrey Firefly MV cameras I found that the driver occasionally fails to read the next frame and gets stuck in an infinite loop with the message: 
`Exception reading data: [Camera1394::readData]: Unable to capture frame`

This pull request introduces a `max_consecutive_errors` config parameter, forcing the driver to close and reopen the connection to the camera if a number of consecutive errors is reached.