### PR TITLE
Increase size of error printing char buffers

### DIFF
--- a/src/nodes/dev_camera1394.cpp
+++ b/src/nodes/dev_camera1394.cpp
@@ -59,16 +59,16 @@
 //! Macro for throwing an exception with a message
 #define CAM_EXCEPT(except, msg)					\
   {								\
-    char buf[100];						\
-    snprintf(buf, 100, "[Camera1394::%s]: " msg, __FUNCTION__); \
+    char buf[200];						\
+    snprintf(buf, 200, "[Camera1394::%s]: " msg, __FUNCTION__); \
     throw except(buf);						\
   }
 
 //! Macro for throwing an exception with a message, passing args
 #define CAM_EXCEPT_ARGS(except, msg, ...)				\
   {									\
-    char buf[100];							\
-    snprintf(buf, 100, "[Camera1394::%s]: " msg, __FUNCTION__, __VA_ARGS__); \
+    char buf[200];							\
+    snprintf(buf, 200, "[Camera1394::%s]: " msg, __FUNCTION__, __VA_ARGS__); \
     throw except(buf);							\
   }
 


### PR DESCRIPTION
The error message at 

https://github.com/ros-drivers/camera1394/blob/abc1950a6925628acc7581cabc312741706b6e4c/src/nodes/dev_camera1394.cpp#L197-L200

is longer than 100 chars, and GCC 8.3 started figuring this out and reports a warning about the buffer being too small (the size computed by gcc is 165 chars).